### PR TITLE
Allow users to send flags to sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ Examples:
   baz, foo'`)
 
 [text-obj-indent plugin]: https://github.com/kana/vim-textobj-indent
+
+Configuration
+-------------
+
+If you'd like to pass any options to `sort`
+you can set `g:sort_motion_flags`. For example you could use:
+
+```vim
+let g:sort_motion_flags = "ui"
+```
+
+To make all sorts case insensitive and remove duplicates.

--- a/plugin/sort_motion.vim
+++ b/plugin/sort_motion.vim
@@ -8,12 +8,16 @@ if exists("g:loaded_sort_motion") || &cp || v:version < 700
 endif
 let g:loaded_sort_motion = 1
 
+if !exists("g:sort_motion_flags")
+  let g:sort_motion_flags = ""
+endif
+
 function! s:sort_motion(type,...) abort
   if a:0
     echo 'in a:0 truthy block'
   else " not in visual
     if a:type == 'line'
-      '[,']sort
+      execute "'[,']sort " . g:sort_motion_flags
     elseif a:type == 'char'
       silent exe "normal! `[v`]y"
       let sorted = join(sort(split(@@, ', ')), ', ')


### PR DESCRIPTION
This allows you to set `g:sort_motion_flags` to `ui` so that you can have case insensitive unique sorts. In theory this could also be translated to the linewise sort, that would definitely be uglier though. Not offended if you don't want to merge this in.
