### PR TITLE
Added the option to use a special command for block selections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ in Vim, it becomes a viable option.
 
 - Linewise: sort a sequence of lines (require statements, gem lists, etc)
 - Character: sort a comma separated list (argument lists, attribute lists, etc)
-- Visual: provided for continuity, similar to linewise
+- Visual (linewise or normal): provided for continuity, similar to linewise
+- Block Visual: By default behaves the same as the other visual modes.
+  Optionally, you can provide a specific sort command which you might use to
+  sort by a column (example: `Vissort`)
 
 Installation
 ------------
@@ -55,11 +58,15 @@ Examples:
 ### Visual
 
 For continuity, `sort-motion` also defines a visual mode mapping for `gs`.
-This behaves as a linewise sort over the lines defined by the visual or block
-selection
+This behaves as a linewise sort over the lines defined by the visual selection.
+
+You can also (optionally) specify a blockwise command to use for block
+selections (example: `Vissort`).
 
 Configuration
 -------------
+
+### sort_motion_flags
 
 If you'd like to pass any options to `sort`
 you can set `g:sort_motion_flags`. For example you could use:
@@ -72,3 +79,17 @@ To make all sorts case insensitive and remove duplicates.
 
 *Note*: this only applies to linewise sorting (including visual), but does
 not apply to the character based sorting of comma separated lists.
+
+### sort_motion_visual_block_command
+
+If you'd like to specify a specific command to use for blockwise selections you
+can set it here. This is useful if for example you want to use `Vissort` so that
+you can sort by a column.
+
+```vim
+let g:sort_motion_visual_block_command = "Vissort"
+```
+
+By default the command used is `sort`.
+
+NOTE: To use `Vissort` you will need to install this plugin.

--- a/plugin/sort_motion.vim
+++ b/plugin/sort_motion.vim
@@ -12,6 +12,10 @@ if !exists("g:sort_motion_flags")
   let g:sort_motion_flags = ""
 endif
 
+if !exists('g:sort_motion_visual_block_command')
+  let g:sort_motion_visual_block_command = 'sort'
+endif
+
 function! s:sort_motion(mode) abort
   if a:mode == 'line'
     execute "'[,']sort " . g:sort_motion_flags
@@ -40,8 +44,10 @@ function! s:sort_motion(mode) abort
     let sorted = join(sort(split(sortables, '\V' . escape(delimiter, '\'))), delimiter)
     execute "normal! v`]c" . prefix . sorted . suffix
     execute "normal! `["
-  elseif a:mode == 'V' || a:mode == ''
+  elseif a:mode == 'V'
     execute "'<,'>sort " . g:sort_motion_flags
+  elseif a:mode ==# ''
+    execute "'<,'>".g:sort_motion_visual_block_command.' '.g:sort_motion_flags
   endif
 endfunction
 


### PR DESCRIPTION
This change allows you to specify a command to use for block selections.

For example, Vissort is a plugin that lets you sort by a block selection rather than by the line (ie, you can select a column of data and the lines are sorted by that column).

To use this new feature, set the new variable `sort_motion_visual_block_command` to the command to use.

By default this variable is set to the standard "sort", but if you have `Vissort` installed and you set it to `Vissort` you will be able to block select text and sort the rows by that column.